### PR TITLE
Allow more control over ceph chart

### DIFF
--- a/ceph/templates/secrets.yaml
+++ b/ceph/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.secrets.use_common_secrets -}}
 ---
 apiVersion: v1
 kind: Secret
@@ -47,3 +48,4 @@ type: Opaque
 data:
   ceph-client-key: |
 {{ include "secrets/ceph-client-key" . | b64enc | indent 4 }}
+{{- end -}}

--- a/ceph/templates/storage.yaml
+++ b/ceph/templates/storage.yaml
@@ -4,13 +4,13 @@
 apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
 metadata:
-    name: general
+    name: {{ .Values.storageclass.name }}
 provisioner: kubernetes.io/rbd
 parameters:
-    monitors: ceph-mon.{{.Release.Namespace}}:6789
-    adminId: admin
-    adminSecretName: pvc-ceph-conf-combined-storageclass
-    adminSecretNamespace: {{.Release.Namespace}}
-    pool: rbd
-    userId: admin
-    userSecretName: pvc-ceph-client-key
+    monitors: {{ .Values.storageclass.monitors | default "ceph.{{ .Release.Namespace }}:6789" }}
+    adminId: {{ .Values.storageclass.admin_id }}
+    adminSecretName: {{ .Values.storageclass.admin_secret_name }}
+    adminSecretNamespace: {{ .Values.storageclass.admin_secret_namespace | default "{{ .Release.Namespace }}" }}
+    pool: {{ .Values.storageclass.pool }}
+    userId: {{ .Values.storageclass.user_id }}
+    userSecretName: {{ .Values.storageclass.user_secret_name }}

--- a/ceph/values.yaml
+++ b/ceph/values.yaml
@@ -7,7 +7,6 @@
 # tunables available - parameterizing more of the elements
 # in the manifests is a work in progress
 
-
 images:
   daemon: quay.io/attcomdev/ceph-daemon:latest
 
@@ -24,3 +23,46 @@ network:
 storage:
   osd_directory: /var/lib/aic-helm/ceph/osd
   var_directory: /var/lib/aic-helm/ceph/ceph
+
+# Setting this to false will assume you will
+# setup and orchestrate your own secrets and 
+# configmaps outside of this helm chart
+# 
+# The list below is in the format of
+#
+#   configMapName:
+#      elementKeyName
+#
+#   ceph.conf: 
+#      ceph.conf
+#      ceph.client.admin.keyring
+#      ceph.client.admin.keyring
+#   ceph.mon.keyring: 
+#      ceph.mon.keyring
+#   ceph-bootstrap-rgw-keyring:
+#      ceph.keyring
+#      ceph.rgw.keyring
+#   ceph-bootstrap-mds-keyring:
+#      ceph.keyring
+#      ceph.mds.keyring
+#   ceph-bootstrap-osd-keyring:
+#      ceph.keyring
+#      ceph.osd.keyring
+#   ceph-client-key:
+#      ceph-client-key
+secrets:
+  use_common_secrets: true
+
+# if you change provision_storage_class to false
+# it is presumed you manage your own storage
+# class definition externally
+storageclass:
+  provision_storage_class: true
+  name: general
+  monitors: nil
+  pool: rbd
+  admin_id: admin
+  admin_secret_name: pvc-ceph-conf-combined-storageclass
+  admin_secret_namespace: nil
+  user_id: admin
+  user_secret_name: pvc-ceph-client-key


### PR DESCRIPTION
* A new boolean value controls whether secrets and
the ceph.conf secret ConfigMaps are installed allowing
you to bring-your-own ceph configs. This should
remove the dependency on having to generate secrets
using the common chart if you have installed your own.

* A new boolean value controls whether we install
a storage class as part of the ceph chart install allowing
you to externally manage this

* More of the ceph values have been converted to values
variables, paving the way for a master yaml to provide input
and overrides to many independent "sub" charts without a parent chart