### PR TITLE
Fix mariadb-deployment.yaml file

### DIFF
--- a/mariadb/templates/mariadb-deployment.yaml
+++ b/mariadb/templates/mariadb-deployment.yaml
@@ -41,8 +41,6 @@ metadata:
 spec:
   replicas: 1
   template:
-    securityContext:
-      runAsUser: 0      
     metadata:
       name: mariadb-{{$v}}
       labels:
@@ -73,6 +71,8 @@ spec:
             }
           }        
     spec:
+      securityContext:
+        runAsUser: 0
       nodeSelector:
         {{ $root.Values.labels.node_selector_key }}: {{ $root.Values.labels.node_selector_value }}
       containers:
@@ -189,7 +189,5 @@ spec:
             name: mariadb-readiness
         - name: mysql-data
           persistentVolumeClaim:
-            matchLabels:
-              server-id: "{{$v}}"
             claimName: mariadb-{{$v}}
   {{ end }}


### PR DESCRIPTION
According to
* http://kubernetes.io/docs/api-reference/extensions/v1beta1/definitions/#_v1_podtemplatespec
* http://kubernetes.io/docs/api-reference/extensions/v1beta1/definitions/#_v1_persistentvolumeclaimvolumesource

SecurityContext is placed in wrong path. What's more persistentVolumeClaim
doesn't support matchLabels.

Signed-off-by: DTadrzak <daniel.tadrzak@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/aic-helm/50)
<!-- Reviewable:end -->
