### PR TITLE
Glance chart bugfixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 B64_DIRS := common/secrets
 B64_EXCLUDE := $(wildcard common/secrets/*.b64)
 
-CHARTS := ceph mariadb rabbitmq memcached keystone openstack
+CHARTS := ceph mariadb rabbitmq GLANCE memcached keystone glance openstack
 COMMON_TPL := common/templates/_globals.tpl
 
-all: common bootstrap mariadb rabbitmq memcached keystone openstack
+all: common bootstrap mariadb rabbitmq memcached keystone glance openstack
 
 common: build-common
 
@@ -19,6 +19,8 @@ mariadb: build-mariadb
 keystone: build-keystone
 
 rabbitmq: build-rabbitmq
+
+glance: build-glance
 
 memcached: build-memcached	
 

--- a/glance/requirements.yaml
+++ b/glance/requirements.yaml
@@ -2,18 +2,3 @@ dependencies:
   - name: common
     repository: http://localhost:8879/charts
     version: 0.1.0
-  - name: mariadb
-    repository: http://localhost:8879/charts
-    version: 0.1.0    
-  - name: rabbitmq
-    repository: http://localhost:8879/charts
-    version: 0.1.0    
-  - name: memcached
-    repository: http://localhost:8879/charts
-    version: 0.1.0
-  - name: keystone
-    repository: http://localhost:8879/charts
-    version: 0.1.0
-  - name: keystone
-    repository: http://localhost:8879/charts
-    version: 0.1.0

--- a/glance/templates/_helpers.tpl
+++ b/glance/templates/_helpers.tpl
@@ -2,4 +2,4 @@
 {{ range $k, $v := . }}{{ if $k }},{{ end }}{{ $v }}{{ end }}
 {{- end -}}
 
-{{ define "keystone_auth" }}auth: "{'auth_url':'{{ .Values.keystone.auth_url }}', 'username':'{{ .Values.keystone.admin_user }}','password':'{{ .Values.keystone.admin_password }}','project_name':'{{ .Values.keystone.admin_project_name }}','domain_name':'default'}"{{end}}
+{{ define "keystone_auth" }}{'auth_url':'{{ .Values.keystone.auth_url }}', 'username':'{{ .Values.keystone.admin_user }}','password':'{{ .Values.keystone.admin_password }}','project_name':'{{ .Values.keystone.admin_project_name }}','domain_name':'default'}{{end}}

--- a/glance/templates/api.yaml
+++ b/glance/templates/api.yaml
@@ -13,6 +13,7 @@ spec:
           {
             "name": "init",
             "image": "quay.io/stackanetes/kubernetes-entrypoint:v0.1.0",
+            "imagePullPolicy": "{{ .Values.images.pull_policy }}",
             "env": [
               {
                 "name": "NAMESPACE",
@@ -39,7 +40,7 @@ spec:
       containers:
         - name: glance-api
           image: {{ .Values.images.api }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.images.pull_policy }}
           command:
           - bash
           - /tmp/start.sh

--- a/glance/templates/db-sync.yaml
+++ b/glance/templates/db-sync.yaml
@@ -10,6 +10,7 @@ spec:
           {
             "name": "init",
             "image": "quay.io/stackanetes/kubernetes-entrypoint:v0.1.0",
+            "imagePullPolicy": "{{ .Values.images.pull_policy }}",
             "env": [
               {
                 "name": "NAMESPACE",
@@ -35,7 +36,7 @@ spec:
       containers:
         - name: glance-db-sync
           image: {{ .Values.images.db_sync }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.images.pull_policy }}
           command:
             - bash
             - /tmp/db-sync.sh

--- a/glance/templates/init.yaml
+++ b/glance/templates/init.yaml
@@ -10,6 +10,7 @@ spec:
           {
             "name": "init",
             "image": "quay.io/stackanetes/kubernetes-entrypoint:v0.1.0",
+            "imagePullPolicy": "{{ .Values.images.pull_policy }}",
             "env": [
               {
                 "name": "NAMESPACE",
@@ -35,7 +36,7 @@ spec:
       containers:
         - name: glance-init
           image: {{ .Values.images.init }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.images.pull_policy }}
           env:
           - name: ANSIBLE_LIBRARY
             value: /usr/share/ansible/

--- a/glance/templates/post.sh.yaml
+++ b/glance/templates/post.sh.yaml
@@ -6,9 +6,41 @@ data:
   post.sh: |+
     #!/bin/bash
     set -ex
-    export HOME=/tmp
     
-    ansible localhost -vvv -m kolla_keystone_service -a "service_name=glance service_type=image description='Openstack Image' endpoint_region={{ .Values.keystone.glance_region_name }} url='http://glance-api:{{ .Values.network.port.api }}' interface=admin region_name={{ .Values.keystone.admin_region_name }} auth='{{ include "keystone_auth" . }}'" -e "{ 'openstack_glance_auth': {{ include "keystone_auth" . }} }"
-    ansible localhost -vvv -m kolla_keystone_service -a "service_name=glance service_type=image description='Openstack Image' endpoint_region={{ .Values.keystone.glance_region_name }} url='http://glance-api:{{ .Values.network.port.api }}' interface=internal region_name={{ .Values.keystone.admin_region_name }} auth='{{ include "keystone_auth" . }}'" -e "{ 'openstack_glance_auth': {{ include "keystone_auth" . }} }"
-    ansible localhost -vvv -m kolla_keystone_service -a "service_name=glance service_type=image description='Openstack Image' endpoint_region={{ .Values.keystone.glance_region_name }} url='http://glance-api:{{ .Values.network.port.api }}' interface=public region_name={{ .Values.keystone.admin_region_name }} auth='{{ include "keystone_auth" . }}' " -e "{ 'openstack_glance_auth': {{ include "keystone_auth" . }} }"
-    ansible localhost -vvv -m kolla_keystone_user -a "project=service user={{ .Values.keystone.glance_user }} password={{ .Values.keystone.glance_password }} role=admin region_name={{ .Values.keystone.admin_region_name }} auth='{{ include "keystone_auth" . }}'" -e "{'openstack_glance_auth': {{ include "keystone_auth" .}}}"
+    ansible localhost -vvv -m kolla_keystone_service -a 'service_name=glance \
+    service_type=image \
+    description="Openstack Image" \
+    endpoint_region="{{ .Values.keystone.glance_region_name }}" \
+    url="http://glance-api:{{ .Values.network.port.api }}" \
+    interface=admin \
+    region_name="{{ .Values.keystone.admin_region_name }}" \
+    auth="{# openstack_glance_auth #}"' \
+    -e "{ 'openstack_glance_auth': {{ include "keystone_auth" . }} }"
+
+    ansible localhost -vvv -m kolla_keystone_service -a 'service_name=glance \
+    service_type=image \
+    description="Openstack Image" \
+    endpoint_region="{{ .Values.keystone.glance_region_name }}" \
+    url="http://glance-api:{{ .Values.network.port.api }}" \
+    interface=internal \
+    region_name="{{ .Values.keystone.admin_region_name }}" \
+    auth="{# openstack_glance_auth #}"' \
+    -e "{ 'openstack_glance_auth': {{ include "keystone_auth" . }} }"
+
+    ansible localhost -vvv -m kolla_keystone_service -a 'service_name=glance \
+    service_type=image \
+    description="Openstack Image" \
+    endpoint_region="{{ .Values.keystone.glance_region_name }}" \
+    url="http://glance-api:{{ .Values.network.port.api }}" \
+    interface=public \
+    region_name="{{ .Values.keystone.admin_region_name }}" \
+    auth="{# openstack_glance_auth #}"' \
+    -e "{ 'openstack_glance_auth': {{ include "keystone_auth" . }} }"
+
+    ansible localhost -vvv -m kolla_keystone_user -a "project=service \
+    user={{ .Values.keystone.glance_user }} \
+    password={{ .Values.keystone.glance_password }} \
+    role=admin \
+    region_name={{ .Values.keystone.admin_region_name }} \
+    auth="{# openstack_glance_auth #}"' \
+    -e "{ 'openstack_glance_auth': {{ include "keystone_auth" . }} }"

--- a/glance/templates/post.yaml
+++ b/glance/templates/post.yaml
@@ -10,6 +10,7 @@ spec:
           {
             "name": "init",
             "image": "quay.io/stackanetes/kubernetes-entrypoint:v0.1.0",
+            "imagePullPolicy": "{{ .Values.images.pull_policy }}",
             "env": [
               {
                 "name": "NAMESPACE",
@@ -35,7 +36,7 @@ spec:
       containers:
         - name: glance-post
           image: {{ .Values.images.post }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.images.pull_policy }}
           command:
             - bash
             - /tmp/post.sh

--- a/glance/templates/registry.yaml
+++ b/glance/templates/registry.yaml
@@ -13,6 +13,7 @@ spec:
           {
             "name": "init",
             "image": "quay.io/stackanetes/kubernetes-entrypoint:v0.1.0",
+            "imagePullPolicy": "{{ .Values.images.pull_policy }}",
             "env": [
               {
                 "name": "NAMESPACE",
@@ -39,9 +40,9 @@ spec:
       containers:
         - name: glance-registry
           image: {{ .Values.images.registry }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.images.pull_policy }}
           command:
-          - glance-registr
+          - glance-registry
           ports:
             - containerPort: {{ .Values.network.port.registry }}
           readinessProbe:

--- a/glance/values.yaml
+++ b/glance/values.yaml
@@ -15,6 +15,7 @@ images:
   init: quay.io/stackanetes/stackanetes-kolla-toolbox:newton
   registry: quay.io/stackanetes/stackanetes-glance-registry:newton
   post: quay.io/stackanetes/stackanetes-kolla-toolbox:newton
+  pull_policy: "IfNotPresent"
 
 keystone:
   auth_uri: "http://keystone-api:5000"
@@ -91,7 +92,7 @@ dependencies:
     - glance-db-sync
     - keystone-db-sync
     - keystone-init
-    - mariadb-init
+    - mariadb-seed
     service:
     - mariadb
     - keystone-api


### PR DESCRIPTION
* imagePullPolicy requirements for init-containers as required by helm 2.1.0 which does not supply this by default

* dependency tree specified mariadb-init, when there is only a
mariadb-seed job to depend on

* the requirements.yaml should not include any chart in this
repository other then common as that severely complicates
removing charts as all dependent elements are removed with it

* the post.sh.yaml has HOME set to /tmp which will not read
/home/ansible configuration.  It was unclear if this was by
design, but /home/ansible seems like an important part of the
kolla toolbox

* the post.sh.yaml file had quoting typos, but even when they are
fixed the job/glance-post will not run to completion, complaining
of a missing kolla_keystone_service module

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/aic-helm/52)
<!-- Reviewable:end -->
