### PR TITLE
Keystone chart bugfixes

### DIFF
--- a/common/templates/_hosts.tpl
+++ b/common/templates/_hosts.tpl
@@ -8,7 +8,7 @@
 {{- define "mariadb_host"}}mariadb.{{.Release.Namespace}}.svc.{{ include "region" . }}.{{ include "tld" . }}{{- end}}
 
 # keystone
-{{- define "keystone_db_host"}}{{ include "mariadb_host" . }}{{end}}
+{{- define "keystone_db_host"}}{{ include "mariadb_host" . }}{{- end}}
 {{- define "keystone_api_endpoint_host_admin"}}keystone-api.{{.Release.Namespace}}.svc.{{ include "region" . }}.{{ include "tld" . }}{{- end}}
 {{- define "keystone_api_endpoint_host_internal"}}keystone-api.{{.Release.Namespace}}.svc.{{ include "region" . }}.{{ include "tld" . }}{{- end}}
 {{- define "keystone_api_endpoint_host_public"}}keystone-api.{{ include "region" . }}.{{ include "tld" . }}{{- end}}

--- a/keystone/templates/bin/_start.sh.tpl
+++ b/keystone/templates/bin/_start.sh.tpl
@@ -1,0 +1,8 @@
+#!/bin/bash		
+set -ex		
+		
+# Loading Apache2 ENV variables		
+source /etc/apache2/envvars		
+
+# start apache with any container arguments
+apache2 -DFOREGROUND $*

--- a/keystone/templates/configmap-bin.yaml
+++ b/keystone/templates/configmap-bin.yaml
@@ -7,3 +7,5 @@ data:
 {{ tuple "bin/_db-sync.sh.tpl" . | include "template" | indent 4 }}
   init.sh: |
 {{ tuple "bin/_init.sh.tpl" . | include "template" | indent 4 }}
+  start.sh: |
+{{ tuple "bin/_start.sh.tpl" . | include "template" | indent 4 }}

--- a/keystone/templates/configmap-etc.yaml
+++ b/keystone/templates/configmap-etc.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   keystone.conf: |+
 {{ tuple "etc/_keystone.conf.tpl" . | include "template" | indent 4 }}
-  mpm-event.conf: |+
+  mpm_event.conf: |+
 {{ tuple "etc/_mpm_event.conf.tpl" . | include "template" | indent 4 }}  
   wsgi-keystone.conf: |+
 {{ tuple "etc/_wsgi-keystone.conf.tpl" . | include "template" | indent 4 }}

--- a/keystone/templates/deployment.yaml
+++ b/keystone/templates/deployment.yaml
@@ -13,6 +13,7 @@ spec:
           {
             "name": "init",
             "image": "{{ .Values.images.entrypoint }}",
+            "imagePullPolicy": "{{ .Values.images.pull_policy }}",
             "env": [
               {
                 "name": "NAMESPACE",
@@ -43,9 +44,10 @@ spec:
       containers:
         - name: keystone-api
           image: {{ .Values.images.api }}
+          imagePullPolicy: {{ .Values.images.pull_policy }}
           command:
-            - apache2
-            - -DFOREGROUND
+            - bash
+            - /tmp/start.sh
           ports:
             - containerPort: {{ .Values.network.port.public }}
             - containerPort: {{ .Values.network.port.admin }}
@@ -58,26 +60,23 @@ spec:
               subPath: keystone.conf
             - name: wsgikeystone
               mountPath: /etc/apache2/conf-enabled/wsgi-keystone.conf
-              subPath: wsgi_keystone.conf
+              subPath: wsgi-keystone.conf
             - name: mpmeventconf
               mountPath: /etc/apache2/mods-available/mpm_event.conf
               subPath: mpm_event.conf
+            - name: startsh
+              mountPath: /tmp/start.sh
+              subPath: start.sh
       volumes:
         - name: keystoneconf
           configMap:
             name: keystone-etc
-            items:
-            - key: keystone.conf
-              path: keystone.conf
         - name: wsgikeystone
           configMap:
             name: keystone-etc
-            items:
-            - key: wsgi-keystone.conf
-              path: wsgi_keystone.conf
         - name: mpmeventconf
           configMap:
             name: keystone-etc
-            items:
-            - key: mpm-event.conf
-              path: mpm_event.conf
+        - name: startsh
+          configMap:
+            name: keystone-bin

--- a/keystone/templates/deployment.yaml
+++ b/keystone/templates/deployment.yaml
@@ -80,3 +80,4 @@ spec:
         - name: startsh
           configMap:
             name: keystone-bin
+

--- a/keystone/templates/job-db-sync.yaml
+++ b/keystone/templates/job-db-sync.yaml
@@ -10,6 +10,7 @@ spec:
           {
             "name": "init",
             "image": "{{ .Values.images.entrypoint }}",
+            "imagePullPolicy": "{{ .Values.images.pull_policy }}",
             "env": [
               {
                 "name": "NAMESPACE",
@@ -35,7 +36,7 @@ spec:
       containers:
         - name: keystone-db-sync
           image: {{ .Values.images.db_sync }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.images.pull_policy }}
           command:
             - bash
             - /tmp/db-sync.sh

--- a/keystone/templates/job-init.yaml
+++ b/keystone/templates/job-init.yaml
@@ -10,6 +10,7 @@ spec:
           {
             "name": "init",
             "image": "{{ .Values.images.entrypoint }}",
+            "imagePullPolicy": "{{ .Values.images.pull_policy }}",
             "env": [
               {
                 "name": "NAMESPACE",
@@ -35,7 +36,7 @@ spec:
       containers:
         - name: keystone-init
           image: {{ .Values.images.init }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.images.pull_policy }}
           command:
             - bash
             - /tmp/init.sh

--- a/keystone/values.yaml
+++ b/keystone/values.yaml
@@ -14,6 +14,7 @@ images:
   api: quay.io/stackanetes/stackanetes-keystone-api:newton
   init: quay.io/stackanetes/stackanetes-kolla-toolbox:newton
   entrypoint: quay.io/stackanetes/kubernetes-entrypoint:v0.1.0
+  pull_policy: "IfNotPresent"
 
 keystone:
   version: v2.0


### PR DESCRIPTION
* start.sh was added back, which had required env sourcing for successful apache startup.

* the naming convention for charts is finalized with this example
landing on configmap-*.yaml to satisfy those of us with OCD

* imagePullPolicies added for init-containers, required by
helm 2.1.0 which does not supply them by default

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/aic-helm/53)
<!-- Reviewable:end -->
